### PR TITLE
Added SSL support

### DIFF
--- a/transmission/__init__.py
+++ b/transmission/__init__.py
@@ -26,7 +26,7 @@ class BadRequest(Exception): pass
 
 class Transmission(object):
     def __init__(self, host='localhost', port=9091, path='/transmission/rpc',
-                 username=None, password=None):
+                 username=None, password=None, ssl=False):
         """
         Initialize the Transmission client.
 
@@ -34,6 +34,8 @@ class Transmission(object):
         default.
         """
         self.url = "http://%s:%d%s" % (host, port, path)
+        if ssl:
+            self.url = "https://%s:%d%s" % (host, port, path)
         self.headers = {}
         self.tag = 0
 
@@ -50,7 +52,7 @@ class Transmission(object):
 
     def _make_request(self, method, **kwargs):
         body = json.dumps(self._format_request_body(method, **kwargs), cls=TransmissionJSONEncoder)
-        response = requests.post(self.url, data=body, headers=self.headers, auth=self.auth)
+        response = requests.post(self.url, data=body, headers=self.headers, auth=self.auth, verify=False)
         if response.status_code == CSRF_ERROR_CODE:
             self.headers[CSRF_HEADER] = response.headers[CSRF_HEADER]
             return self._make_request(method, **kwargs)


### PR DESCRIPTION
Just pass 'ssl=True' to Transmission() and it will automatically use HTTPS to communicate with your transmission host.  Since transmission-daemon doesn't natively support SSL (yet) you'll need to put it behind an SSL proxy for it to work.  I highly recommend Nginx.  Here's an example Nginx config:

```
server {
    listen <IP address>:<port>;
    # Allow file uploads
    client_max_body_size 5M;

    ssl on;
    ssl_certificate /etc/ssl/certs/transmission-cert.pem;
    ssl_certificate_key    /etc/ssl/private/transmission-key.pem;

    location / {
            proxy_set_header    X-Real-IP  $remote_addr;
            proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header    Host $http_host;
            proxy_redirect      off;
            proxy_pass          http://127.0.0.1:9091;
    }
}
```
